### PR TITLE
Fix MacOS Compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html
 # The following five lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(esp32-bt2ps2)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "main.cpp" "bt_keyboard.cpp" "esp32-ps2dev.cpp" "${app_sources}"
+idf_component_register(SRCS "main.cpp" "bt_keyboard.cpp" "esp32-ps2dev.cpp" "serial_mouse.cpp" "${app_sources}"
                        REQUIRES esp_hid nvs_flash driver)
 
                        component_compile_options(-Wno-error=format= -Wno-format)

--- a/main/bt_keyboard.cpp
+++ b/main/bt_keyboard.cpp
@@ -21,7 +21,7 @@
 // limitations under the License.
 
 #define __BT_KEYBOARD__ 1
-#include "..\include\bt_keyboard.hpp"
+#include "../include/bt_keyboard.hpp"
 
 #include <cstring>
 #include <algorithm>

--- a/main/esp32-ps2dev.cpp
+++ b/main/esp32-ps2dev.cpp
@@ -1,4 +1,4 @@
-#include "..\include\esp32-ps2dev.h"
+#include "../include/esp32-ps2dev.h"
 #define NOP() asm volatile("nop")
 #define HIGH 0x1
 #define LOW 0x0

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -8,15 +8,15 @@ Dedicated to all who love me and all who I love.
 Never stop dreaming.
 */
 
-#include "..\include\globals.hpp"
+#include "../include/globals.hpp"
 #include "nvs_flash.h"
 #include "esp_system.h"
-#include "driver\gpio.h"
+#include "driver/gpio.h"
 #include <iostream>
 #include <cmath>
-#include "..\include\bt_keyboard.hpp" // Interface with a BT/BLE peripheral device (Keyboard & Mouse)
-#include "..\include\esp32-ps2dev.h"  // Emulate a PS/2 device
-#include "..\include\serial_mouse.h"  // Emulate a serial mouse
+#include "../include/bt_keyboard.hpp" // Interface with a BT/BLE peripheral device (Keyboard & Mouse)
+#include "../include/esp32-ps2dev.h"  // Emulate a PS/2 device
+#include "../include/serial_mouse.h"  // Emulate a serial mouse
 
 /////////////////////////////// USER ADJUSTABLE VARIABLES //////////////////////////////////////////////////
 

--- a/main/serial_mouse.cpp
+++ b/main/serial_mouse.cpp
@@ -1,8 +1,8 @@
 // This module contains code from the PS/2 to Serial mouse project by Necroware
 // Adapted and modified by Hambert - HamCode - 2024
 
-#include "..\include\serial_mouse.h"
-#include "..\include\esp32-ps2dev.h"
+#include "../include/serial_mouse.h"
+#include "../include/esp32-ps2dev.h"
 #define NOP() asm volatile("nop")
 
 static bool threeButtons = false;


### PR DESCRIPTION
- **Use Unix style path names in includes**
- **Add serial_mouse.cpp to SRCS**
- **Raise cmake minimum version**
